### PR TITLE
Arch simplification

### DIFF
--- a/Source/Meadow.ProjectLab/IProjectLabHardware.cs
+++ b/Source/Meadow.ProjectLab/IProjectLabHardware.cs
@@ -1,15 +1,27 @@
-﻿using Meadow.Foundation.Displays;
+﻿using System;
+using Meadow.Foundation.Audio;
+using Meadow.Foundation.Displays;
+using Meadow.Foundation.Sensors.Accelerometers;
+using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
+using Meadow.Foundation.Sensors.Light;
+using Meadow.Hardware;
 
 namespace Meadow.Devices
 {
-    internal interface IProjectLabHardware
+    public interface IProjectLabHardware
     {
-        public St7789 GetDisplay();
-        public PushButton GetLeftButton();
-        public PushButton GetRightButton();
-        public PushButton GetUpButton();
-        public PushButton GetDownButton();
-        public string GetRevisionString();
+        public ISpiBus SpiBus { get; set; }
+        public II2cBus I2CBus { get; set; }
+        public St7789? Display { get; set; }
+        public Bh1750? LightSensor { get; set; }
+        public Bme688? EnvironmentalSensor { get; set; }
+        public Bmi270? MotionSensor { get; set; }
+        public PiezoSpeaker Speaker { get; set; }
+        public PushButton LeftButton { get; set; }
+        public PushButton RightButton { get; set; }
+        public PushButton UpButton { get; set; }
+        public PushButton DownButton { get; set; }
+        public string RevisionString { get; }
     }
 }

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
@@ -1,86 +1,112 @@
-﻿using Meadow.Foundation.Displays;
+﻿using System;
+using Meadow.Foundation.Audio;
+using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
+using Meadow.Foundation.Sensors.Accelerometers;
+using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
+using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
-using System;
 
 namespace Meadow.Devices
 {
     internal class ProjectLabHardwareV1 : IProjectLabHardware
     {
         private IF7FeatherMeadowDevice device;
-        private ISpiBus spiBus;
-        private St7789? display;
-        private PushButton? rightButton;
+        public ISpiBus SpiBus { get; set; }
+        public II2cBus I2CBus { get; set; }
+        public Bh1750? LightSensor { get; set; }
+        public Bme688? EnvironmentalSensor { get; set; }
+        public Bmi270? MotionSensor { get; set; }
+        public PiezoSpeaker Speaker { get; set; }
         private string revision = "v1.x";
 
         public ProjectLabHardwareV1(IF7FeatherMeadowDevice device, ISpiBus spiBus)
         {
             this.device = device;
-            this.spiBus = spiBus;
+            this.SpiBus = spiBus;
         }
 
-        public string GetRevisionString()
-        {
-            return revision;
-        }
+        public string RevisionString => revision;
 
-        public St7789 GetDisplay()
+        public St7789 Display
         {
-            if (display == null)
+            get
             {
-                display = new St7789(
-                    device: device,
-                    spiBus: spiBus,
-                    chipSelectPin: device.Pins.A03,
-                    dcPin: device.Pins.A04,
-                    resetPin: device.Pins.A05,
-                    width: 240, height: 240,
-                    colorMode: ColorType.Format16bppRgb565);
-            }
+                if (display == null)
+                {
+                    display = new St7789(
+                        device: device,
+                        spiBus: SpiBus,
+                        chipSelectPin: device.Pins.A03,
+                        dcPin: device.Pins.A04,
+                        resetPin: device.Pins.A05,
+                        width: 240, height: 240,
+                        colorMode: ColorType.Format16bppRgb565);
+                }
 
-            return display;
+                return display;
+            }
+            set { display = value; }
+        }
+        protected St7789 display;
+
+        public PushButton LeftButton
+        {
+            get
+            {
+                if (Resolver.Device is F7FeatherV2)
+                {
+                    // D10 no interrupts
+                }
+                throw new PlatformNotSupportedException("A hardware bug prevents usage of the Left button on ProjectLab v1 hardware.");
+            }
+            set { throw new Exception("Don't set this."); }
         }
 
-        public PushButton GetLeftButton()
+        public PushButton RightButton
         {
-            if (Resolver.Device is F7FeatherV2)
+            get
             {
-                // D10 no interrupts
+                if (rightButton == null)
+                {
+                    rightButton = new PushButton(
+                        Resolver.Device.CreateDigitalInputPort(
+                            device.Pins.D05,
+                            InterruptMode.EdgeBoth,
+                            ResistorMode.InternalPullDown));
+                }
+                return rightButton;
             }
-            throw new PlatformNotSupportedException("A hardware bug prevents usage of the Left button on ProjectLab v1 hardware.");
+            set { throw new Exception("Don't set this."); }
+        }
+        protected PushButton rightButton;
+
+        public PushButton UpButton
+        {
+            get
+            {
+                // D15
+                if (Resolver.Device is F7FeatherV2)
+                {
+                    // D15 no interrupts
+                }
+                throw new PlatformNotSupportedException("A hardware bug prevents usage of the Up button on ProjectLab v1 hardware.");
+            }
+            set { throw new Exception("Don't set this."); }
         }
 
-        public PushButton GetRightButton()
+        public PushButton DownButton
         {
-            if (rightButton == null)
+            get
             {
-                rightButton = new PushButton(
-                    Resolver.Device.CreateDigitalInputPort(
-                        device.Pins.D05,
-                        InterruptMode.EdgeBoth,
-                        ResistorMode.InternalPullDown));
+                if (Resolver.Device is F7FeatherV2)
+                {
+                    // D02 no interrupts
+                }
+                throw new PlatformNotSupportedException("A hardware bug prevents usage of the Down button on ProjectLab v1 hardware.");
             }
-            return rightButton;
-        }
-
-        public PushButton GetUpButton()
-        {
-            // D15
-            if (Resolver.Device is F7FeatherV2)
-            {
-                // D15 no interrupts
-            }
-            throw new PlatformNotSupportedException("A hardware bug prevents usage of the Up button on ProjectLab v1 hardware.");
-        }
-
-        public PushButton GetDownButton()
-        {
-            if (Resolver.Device is F7FeatherV2)
-            {
-                // D02 no interrupts
-            }
-            throw new PlatformNotSupportedException("A hardware bug prevents usage of the Down button on ProjectLab v1 hardware.");
+            set { throw new Exception("Don't set this."); }
         }
     }
 }

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
@@ -1,112 +1,150 @@
-﻿using Meadow.Foundation.Displays;
+﻿using System;
+using System.Threading;
+using Meadow.Foundation.Audio;
+using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
 using Meadow.Foundation.ICs.IOExpanders;
+using Meadow.Foundation.Sensors.Accelerometers;
+using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
+using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
-using System.Threading;
+using Meadow.Logging;
 
 namespace Meadow.Devices
 {
     internal class ProjectLabHardwareV2 : IProjectLabHardware
     {
+        protected Logger? Logger { get; } = Resolver.Log;
+
         private IF7FeatherMeadowDevice device;
-        private ISpiBus spiBus;
+        public ISpiBus SpiBus { get; set; }
+        public II2cBus I2CBus { get; set; }
+        public Bh1750? LightSensor { get; set; }
+        public Bme688? EnvironmentalSensor { get; set; }
+        public Bmi270? MotionSensor { get; set; }
+        public PiezoSpeaker Speaker { get; set; }
         private Mcp23008 mcp1;
         private Mcp23008? mcpVersion;
-
-        private St7789? display;
-        private PushButton? leftButton;
-        private PushButton? rightButton;
-        private PushButton? upButton;
-        private PushButton? downButton;
-        private string? revision;
 
         public ProjectLabHardwareV2(Mcp23008 mcp1, Mcp23008? mcpVersion, IF7FeatherMeadowDevice device, ISpiBus spiBus)
         {
             this.device = device;
-            this.spiBus = spiBus;
+            this.SpiBus = spiBus;
             this.mcp1 = mcp1;
             this.mcpVersion = mcpVersion;
         }
 
-        public string GetRevisionString()
+        public string RevisionString
         {
-            // TODO: figure this out from MCP3?
-            if (revision == null)
+            get
             {
-                if (mcpVersion == null)
+                // TODO: figure this out from MCP3?
+                if (revision == null)
                 {
-                    revision = $"v2.x";
+                    if (mcpVersion == null)
+                    {
+                        revision = $"v2.x";
+                    }
+                    else
+                    {
+                        byte rev = mcpVersion.ReadFromPorts(Mcp23xxx.PortBank.A);
+                        //mapping? 0 == d2.d?
+                        revision = $"v2.{rev}";
+                    }
                 }
-                else
+                return revision;
+            }
+        }
+        protected string? revision;
+
+        public St7789 Display
+        {
+            get
+            {
+                if (display == null)
                 {
-                    byte rev = mcpVersion.ReadFromPorts(Mcp23xxx.PortBank.A);
-                    //mapping? 0 == d2.d?
-                    revision = $"v2.{rev}";
+                    Logger?.Info("Instantiating display.");
+                    var chipSelectPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP5);
+                    var dcPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP6);
+                    var resetPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP7);
+
+                    Thread.Sleep(50);
+
+                    display = new St7789(
+                        spiBus: SpiBus,
+                        chipSelectPort: chipSelectPort,
+                        dataCommandPort: dcPort,
+                        resetPort: resetPort,
+                        width: 240, height: 240,
+                        colorMode: ColorType.Format16bppRgb565);
+                    Logger?.Info("Display up.");
                 }
+                return display;
             }
-            return revision;
+            set { display = value; }
         }
+        protected St7789? display;
 
-        public St7789 GetDisplay()
+
+        public PushButton LeftButton
         {
-            if (display == null)
+            get
             {
-                var chipSelectPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP5);
-                var dcPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP6);
-                var resetPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP7);
-
-                Thread.Sleep(50);
-
-                display = new St7789(
-                    spiBus: spiBus,
-                    chipSelectPort: chipSelectPort,
-                    dataCommandPort: dcPort,
-                    resetPort: resetPort,
-                    width: 240, height: 240,
-                    colorMode: ColorType.Format16bppRgb565);
+                if (leftButton == null)
+                {
+                    var leftPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP2, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    leftButton = new PushButton(leftPort);
+                }
+                return leftButton;
             }
-            return display;
+            set { throw new Exception("Don't set this."); }
         }
+        protected PushButton? leftButton;
 
-        public PushButton GetLeftButton()
+        public PushButton RightButton
         {
-            if (leftButton == null)
+            get
             {
-                var leftPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP2, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                leftButton = new PushButton(leftPort);
+                if (rightButton == null)
+                {
+                    var rightPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP1, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    rightButton = new PushButton(rightPort);
+                }
+                return rightButton;
             }
-            return leftButton;
+            set { throw new Exception("Don't set this."); }
         }
+        protected PushButton? rightButton;
 
-        public PushButton GetRightButton()
+        public PushButton UpButton
         {
-            if (rightButton == null)
+            get
             {
-                var rightPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP1, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                rightButton = new PushButton(rightPort);
+                if (upButton == null)
+                {
+                    var upPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP0, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    upButton = new PushButton(upPort);
+                }
+                return upButton;
             }
-            return rightButton;
+            set { throw new Exception("Don't set this."); }
         }
+        protected PushButton? upButton;
 
-        public PushButton GetUpButton()
+        public PushButton DownButton
         {
-            if (upButton == null)
+            get
             {
-                var upPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP0, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                upButton = new PushButton(upPort);
+                if (downButton == null)
+                {
+                    var downPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP3, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    downButton = new PushButton(downPort);
+                }
+                return downButton;
             }
-            return upButton;
+            set { throw new Exception("Don't set this."); }
         }
-
-        public PushButton GetDownButton()
-        {
-            if (downButton == null)
-            {
-                var downPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP3, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                downButton = new PushButton(downPort);
-            }
-            return downButton;
-        }
+        protected PushButton? downButton;
     }
 }

--- a/Source/ProjectLab_Demo/MeadowApp.cs
+++ b/Source/ProjectLab_Demo/MeadowApp.cs
@@ -1,6 +1,8 @@
 ﻿using Meadow;
 using Meadow.Devices;
 using Meadow.Foundation;
+using Meadow.Foundation.Leds;
+using Meadow.Peripherals.Leds;
 using Meadow.Units;
 using System;
 using System.Threading.Tasks;
@@ -10,6 +12,7 @@ namespace ProjLab_Demo
     // Change F7FeatherV2 to F7FeatherV1 for V1.x boards
     public class MeadowApp : App<F7FeatherV2>
     {
+        RgbPwmLed onboardLed;
         DisplayController displayController;
         ProjectLab projLab;
 
@@ -17,9 +20,20 @@ namespace ProjLab_Demo
         {
             Console.WriteLine("Initialize hardware...");
 
+
+            //---- Onboard RGB LED
+            Resolver.Log.Info("Initializing onboard RGB LED.");
+            onboardLed = new RgbPwmLed(device: Device,
+                redPwmPin: Device.Pins.OnboardLedRed,
+                greenPwmPin: Device.Pins.OnboardLedGreen,
+                bluePwmPin: Device.Pins.OnboardLedBlue,
+                CommonType.CommonAnode);
+            Resolver.Log.Info("RGB LED up.");
+
+            //--- Project Lab Hardware
             projLab = new ProjectLab();
 
-            Resolver.Log.Info($"Running on ProjectLab Hardware {projLab.HardwareRevision}");
+            Resolver.Log.Info($"Running on ProjectLab Hardware {projLab.RevisionString}");
 
             if (projLab.Display is { } display)
             {
@@ -87,7 +101,7 @@ namespace ProjLab_Demo
             }
 
             //---- heartbeat
-            projLab.Led.StartPulse(WildernessLabsColors.PearGreen);
+            onboardLed.StartPulse(WildernessLabsColors.PearGreen);
 
             Console.WriteLine("Initialization complete");
 
@@ -131,7 +145,7 @@ namespace ProjLab_Demo
             }
 
             Console.WriteLine("starting blink");
-            projLab.Led.StartBlink(WildernessLabsColors.PearGreen, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(2000), 0.5f);
+            onboardLed.StartBlink(WildernessLabsColors.PearGreen, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(2000), 0.5f);
 
             return base.Run();
         }


### PR DESCRIPTION
 - I needed the `IProjectLabHardware` interface exposed so I could extend it in a consumer application.
 - Removed the `Lazy<x>` initialization. They didn't speed anything up and they convoluted the code a whole lot.