### PR TITLE
Arch simplification

### DIFF
--- a/Source/Meadow.ProjectLab/IProjectLabHardware.cs
+++ b/Source/Meadow.ProjectLab/IProjectLabHardware.cs
@@ -1,18 +1,32 @@
-﻿using Meadow.Foundation.Displays;
+﻿using Meadow.Foundation.Audio;
+using Meadow.Foundation.Displays;
+using Meadow.Foundation.Sensors.Accelerometers;
+using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
+using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
 using Meadow.Modbus;
 
 namespace Meadow.Devices
 {
-    internal interface IProjectLabHardware
+    public interface IProjectLabHardware
     {
-        public St7789 GetDisplay();
-        public PushButton GetLeftButton();
-        public PushButton GetRightButton();
-        public PushButton GetUpButton();
-        public PushButton GetDownButton();
-        public string GetRevisionString();
+        public ISpiBus SpiBus { get; set; }
+        public II2cBus I2cBus { get; set; }
+        //public ModbusRtuClient ModbusRtuClieint { get; set; }
         public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One);
+
+        public St7789? Display { get; set; }
+        public Bh1750? LightSensor { get; set; }
+        public Bme688? EnvironmentalSensor { get; set; }
+        public Bmi270? MotionSensor { get; set; }
+        public PiezoSpeaker Speaker { get; set; }
+
+        public PushButton LeftButton { get; set; }
+        public PushButton RightButton { get; set; }
+        public PushButton UpButton { get; set; }
+        public PushButton DownButton { get; set; }
+
+        public string RevisionString { get; }
     }
 }

--- a/Source/Meadow.ProjectLab/IProjectLabHardware.cs
+++ b/Source/Meadow.ProjectLab/IProjectLabHardware.cs
@@ -11,21 +11,20 @@ namespace Meadow.Devices
 {
     public interface IProjectLabHardware
     {
-        public ISpiBus SpiBus { get; set; }
-        public II2cBus I2cBus { get; set; }
-        //public ModbusRtuClient ModbusRtuClieint { get; set; }
+        public ISpiBus SpiBus { get; }
+        public II2cBus I2cBus { get; }
         public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One);
 
-        public St7789? Display { get; set; }
-        public Bh1750? LightSensor { get; set; }
-        public Bme688? EnvironmentalSensor { get; set; }
-        public Bmi270? MotionSensor { get; set; }
-        public PiezoSpeaker Speaker { get; set; }
+        public St7789? Display { get; }
+        public Bh1750? LightSensor { get; }
+        public Bme688? EnvironmentalSensor { get; }
+        public Bmi270? MotionSensor { get; }
+        public PiezoSpeaker? Speaker { get; }
 
-        public PushButton LeftButton { get; set; }
-        public PushButton RightButton { get; set; }
-        public PushButton UpButton { get; set; }
-        public PushButton DownButton { get; set; }
+        public PushButton? LeftButton { get; }
+        public PushButton? RightButton { get; }
+        public PushButton? UpButton { get; }
+        public PushButton? DownButton { get; }
 
         public string RevisionString { get; }
     }

--- a/Source/Meadow.ProjectLab/ProjectLab.cs
+++ b/Source/Meadow.ProjectLab/ProjectLab.cs
@@ -1,16 +1,9 @@
-using Meadow.Foundation.Audio;
-using Meadow.Foundation.Displays;
+using System;
 using Meadow.Foundation.ICs.IOExpanders;
-using Meadow.Foundation.Leds;
-using Meadow.Foundation.Sensors.Accelerometers;
-using Meadow.Foundation.Sensors.Atmospheric;
-using Meadow.Foundation.Sensors.Buttons;
-using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
 using Meadow.Logging;
 using Meadow.Modbus;
 using Meadow.Units;
-using System;
 
 namespace Meadow.Devices
 {

--- a/Source/Meadow.ProjectLab/ProjectLab.cs
+++ b/Source/Meadow.ProjectLab/ProjectLab.cs
@@ -17,65 +17,7 @@ namespace Meadow.Devices
     public class ProjectLab
     {
         protected Logger? Logger { get; } = Resolver.Log;
-        public ISpiBus SpiBus { get; }
-        public II2cBus I2CBus { get; }
-
-        private readonly Lazy<RgbPwmLed> led;
-        private readonly Lazy<St7789?> display;
-        private readonly Lazy<Bh1750?> lightSensor;
-        private readonly Lazy<PushButton> upButton;
-        private readonly Lazy<PushButton> downButton;
-        private readonly Lazy<PushButton> leftButton;
-        private readonly Lazy<PushButton> rightButton;
-        private readonly Lazy<Bme688?> environmentalSensor;
-        private readonly Lazy<PiezoSpeaker> speaker;
-        private readonly Lazy<Bmi270?> motionSensor;
-
-        /// <summary>
-        /// Gets the RGB LED on the Meadow Feather itself.
-        /// </summary>
-        public RgbPwmLed Led => led.Value;
-        /// <summary>
-        /// Gets the ST7789 Display on the Project Lab board
-        /// </summary>
-        public St7789? Display => display.Value;
-        /// <summary>
-        /// Gets the BH1750 Light Sensor on the Project Lab board
-        /// </summary>
-        public Bh1750? LightSensor => lightSensor.Value;
-        /// <summary>
-        /// Gets the Up PushButton on the Project Lab board
-        /// </summary>
-        public PushButton UpButton => upButton.Value;
-        /// <summary>
-        /// Gets the Down PushButton on the Project Lab board
-        /// </summary>
-        public PushButton DownButton => downButton.Value;
-        /// <summary>
-        /// Gets the Left PushButton on the Project Lab board
-        /// </summary>
-        public PushButton LeftButton => leftButton.Value;
-        /// <summary>
-        /// Gets the Right PushButton on the Project Lab board
-        /// </summary>
-        public PushButton RightButton => rightButton.Value;
-        /// <summary>
-        /// Gets the BME688 environmental sensor  on the Project Lab board
-        /// </summary>
-        public Bme688? EnvironmentalSensor => environmentalSensor.Value;
-        /// <summary>
-        /// Gets the Piezo noise maker on the Project Lab board
-        /// </summary>
-        public PiezoSpeaker Speaker => speaker.Value;
-        /// <summary>
-        /// Gets the BMI inertial movement unit (IMU) on the Project Lab board
-        /// </summary>
-        public Bmi270? MotionSensor => motionSensor.Value;
-
-        internal IProjectLabHardware Hardware { get; }
-        internal Mcp23008? Mcp_1 { get; }
-        internal Mcp23008? Mcp_2 { get; }
-        internal Mcp23008? Mcp_Version { get; }
+        public IProjectLabHardware Hardware { get; protected set; }
 
         /// <summary>
         /// Create an instance of the ProjectLab class
@@ -83,9 +25,19 @@ namespace Meadow.Devices
         /// <exception cref="Exception"></exception>
         public ProjectLab()
         {
+            // shared stuff
+            II2cBus i2cBus;
+            ISpiBus spiBus;
+
+            // v2+ stuff
+            Mcp23008? mcp_1 = null;
+            Mcp23008? mcp_2 = null;
+            Mcp23008? mcp_Version = null;
+
             Logger?.Debug("Initializing Project Lab...");
 
-            // check to see if we have an MCP23008 - it was introduced in v2 hardware
+            //==== hardware and lifecycle checks
+            // make sure not getting instantiated before the App Initialize method
             if (Resolver.Device == null)
             {
                 var msg = "ProjLab instance must be created no earlier than App.Initialize()";
@@ -102,22 +54,25 @@ namespace Meadow.Devices
                 throw new Exception(msg);
             }
 
-            // create our busses
-            Logger?.Debug("Creating comms busses...");
+            //==== create our busses
+            Logger?.Info("Creating comms busses...");
             var config = new SpiClockConfiguration(
                            new Frequency(48000, Frequency.UnitType.Kilohertz),
                            SpiClockConfiguration.Mode.Mode3);
 
-            SpiBus = Resolver.Device.CreateSpiBus(
+            spiBus = Resolver.Device.CreateSpiBus(
                 device.Pins.SCK,
                 device.Pins.COPI,
                 device.Pins.CIPO,
                 config);
 
-            I2CBus = device.CreateI2cBus();
+            Logger?.Info("SPI Bus instantiated.");
 
-            // determine hardware
+            i2cBus = device.CreateI2cBus();
 
+            Logger?.Info("I2C Bus instantiated.");
+
+            //==== determine hardware
             try
             {
                 // MCP the First
@@ -125,18 +80,22 @@ namespace Meadow.Devices
                     device.Pins.D09, InterruptMode.EdgeRising, ResistorMode.InternalPullDown);
                 IDigitalOutputPort mcp_Reset = device.CreateDigitalOutputPort(device.Pins.D14);
 
-                Mcp_1 = new Mcp23008(I2CBus, address: 0x20, mcp1_int, mcp_Reset);
+                mcp_1 = new Mcp23008(i2cBus, address: 0x20, mcp1_int, mcp_Reset);
+
+                Logger?.Info("Mcp_1 up.");
             }
             catch (Exception e)
             {
-                Logger?.Trace($"Failed to create MCP1: {e.Message}");
+                Logger?.Trace($"Failed to create MCP1: {e.Message}, could be a v1 board.");
             }
             try
             {
                 // MCP the Second
                 IDigitalInputPort mcp2_int = device.CreateDigitalInputPort(
                     device.Pins.D10, InterruptMode.EdgeRising, ResistorMode.InternalPullDown);
-                Mcp_2 = new Mcp23008(I2CBus, address: 0x21, mcp2_int);
+                mcp_2 = new Mcp23008(i2cBus, address: 0x21, mcp2_int);
+
+                Logger?.Info("Mcp_2 up.");
             }
             catch (Exception e)
             {
@@ -144,112 +103,26 @@ namespace Meadow.Devices
             }
             try
             {
-                Mcp_Version = new Mcp23008(I2CBus, address: 0x27);
+                mcp_Version = new Mcp23008(i2cBus, address: 0x27);
+                Logger?.Info("Mcp_Version up.");
             }
             catch (Exception e)
             {
                 Logger?.Trace($"ERR creating the MCP that has version information: {e.Message}");
             }
 
-            if (Mcp_1 == null)
+            //==== instantiate the appropriate hardware per the version
+            if (mcp_1 == null)
             {
-                Hardware = new ProjectLabHardwareV1(device, SpiBus);
+                Logger?.Info("Instantiating Project Lab v1 specific hardware.");
+                Hardware = new ProjectLabHardwareV1(device, spiBus, i2cBus);
             }
             else
             {
-                Hardware = new ProjectLabHardwareV2(Mcp_1, Mcp_2, Mcp_Version, device, SpiBus);
+                Logger?.Info("Instantiating Project Lab v2 specific hardware.");
+                Hardware = new ProjectLabHardwareV2(device, spiBus, i2cBus, mcp_1, mcp_2, mcp_Version);
             }
 
-            // lazy load all components
-            try
-            {
-                led = new Lazy<RgbPwmLed>(() =>
-                    new RgbPwmLed(
-                    device: device,
-                    redPwmPin: device.Pins.OnboardLedRed,
-                    greenPwmPin: device.Pins.OnboardLedGreen,
-                    bluePwmPin: device.Pins.OnboardLedBlue));
-
-                Logger?.Debug("Creating Display...");
-
-                display = new Lazy<St7789?>(() =>
-                {
-                    try
-                    {
-                        return Hardware.GetDisplay();
-                    }
-                    catch (Exception ex)
-                    {
-                        Resolver.Log.Error($"Unable to create the ST7789 Display Light Sensor: {ex.Message}");
-                        return default;
-                    }
-                });
-
-                Logger?.Debug("Creating BH1750...");
-
-                lightSensor = new Lazy<Bh1750?>(() =>
-                {
-                    try
-                    {
-                        return new Bh1750(
-                            i2cBus: I2CBus,
-                            measuringMode: Bh1750.MeasuringModes.ContinuouslyHighResolutionMode, // the various modes take differing amounts of time.
-                            lightTransmittance: 0.5, // lower this to increase sensitivity, for instance, if it's behind a semi opaque window
-                            address: (byte)Bh1750.Addresses.Address_0x23);
-                    }
-                    catch (Exception ex)
-                    {
-                        Resolver.Log.Error($"Unable to create the BH1750 Light Sensor: {ex.Message}");
-                        return default;
-                    }
-                });
-
-                Logger?.Debug("Creating Buttons...");
-
-                rightButton = new Lazy<PushButton>(Hardware.GetRightButton());
-                upButton = new Lazy<PushButton>(Hardware.GetUpButton());
-                leftButton = new Lazy<PushButton>(Hardware.GetLeftButton());
-                downButton = new Lazy<PushButton>(Hardware.GetDownButton());
-
-                Logger?.Debug("Creating BME688...");
-
-                environmentalSensor = new Lazy<Bme688?>(() =>
-                {
-                    try
-                    {
-                        return new Bme688(I2CBus, (byte)Bme688.Addresses.Address_0x76);
-                    }
-                    catch (Exception ex)
-                    {
-                        Resolver.Log.Error($"Unable to create the BME680 Environmental Sensor: {ex.Message}");
-                        return default;
-                    }
-                });
-
-                Logger?.Debug("Creating Piezo...");
-
-                speaker = new Lazy<PiezoSpeaker>(new PiezoSpeaker(device, device.Pins.D11));
-
-                Logger?.Debug("Creating BMI270...");
-
-                motionSensor = new Lazy<Bmi270?>(() =>
-                {
-                    try
-                    {
-                        return new Bmi270(I2CBus);
-                    }
-                    catch (Exception ex)
-                    {
-                        Resolver.Log.Error($"Unable to create the BMI270 IMU: {ex.Message}");
-                        return default;
-                    }
-                });
-            }
-
-            catch (Exception ex)
-            {
-                Logger?.Error($"Error initializing ProjectLab: {ex.Message}");
-            }
         }
 
         /// <summary>
@@ -265,65 +138,5 @@ namespace Meadow.Devices
             return Hardware.GetModbusRtuClient(baudRate, dataBits, parity, stopBits);
         }
 
-        /// <summary>
-        /// Gets the ProjectLab board hardware revision
-        /// </summary>
-        public string HardwareRevision
-        {
-            get => Hardware.GetRevisionString();
-        }
-
-        /// <summary>
-        /// Gets the pin definitions for the Project Lab board
-        /// </summary>
-        public static (
-            IPin MB1_CS,
-            IPin MB1_INT,
-            IPin MB1_PWM,
-            IPin MB1_AN,
-            IPin MB1_SO,
-            IPin MB1_SI,
-            IPin MB1_SCK,
-            IPin MB1_SCL,
-            IPin MB1_SDA,
-
-            IPin MB2_CS,
-            IPin MB2_INT,
-            IPin MB2_PWM,
-            IPin MB2_AN,
-            IPin MB2_SO,
-            IPin MB2_SI,
-            IPin MB2_SCK,
-            IPin MB2_SCL,
-            IPin MB2_SDA,
-
-            IPin A0,
-            IPin D03,
-            IPin D04
-            ) Pins = (
-            Resolver.Device.GetPin("D14"),
-            Resolver.Device.GetPin("D03"),
-            Resolver.Device.GetPin("D04"),
-            Resolver.Device.GetPin("A00"),
-            Resolver.Device.GetPin("CIPO"),
-            Resolver.Device.GetPin("COPI"),
-            Resolver.Device.GetPin("SCK"),
-            Resolver.Device.GetPin("D08"),
-            Resolver.Device.GetPin("D07"),
-
-            Resolver.Device.GetPin("A02"),
-            Resolver.Device.GetPin("D04"),
-            Resolver.Device.GetPin("D03"),
-            Resolver.Device.GetPin("A01"),
-            Resolver.Device.GetPin("CIPO"),
-            Resolver.Device.GetPin("COPI"),
-            Resolver.Device.GetPin("SCK"),
-            Resolver.Device.GetPin("D08"),
-            Resolver.Device.GetPin("D07"),
-
-            Resolver.Device.GetPin("A00"),
-            Resolver.Device.GetPin("D03"),
-            Resolver.Device.GetPin("D04")
-            );
     }
 }

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using Meadow.Devices;
 using Meadow.Foundation.Audio;
 using Meadow.Foundation.Displays;
-using Meadow.Foundation.ICs.IOExpanders;
 using Meadow.Foundation.Sensors.Accelerometers;
 using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
@@ -10,7 +8,6 @@ using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
 using Meadow.Logging;
 using Meadow.Modbus;
-using Meadow.Units;
 
 namespace Meadow.Devices
 {

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
@@ -195,4 +195,3 @@ namespace Meadow.Devices
             );
     }
 }
-

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Meadow.Foundation.Audio;
+﻿using Meadow.Foundation.Audio;
 using Meadow.Foundation.Displays;
 using Meadow.Foundation.Sensors.Accelerometers;
 using Meadow.Foundation.Sensors.Atmospheric;
@@ -8,13 +7,14 @@ using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
 using Meadow.Logging;
 using Meadow.Modbus;
+using System;
 
 namespace Meadow.Devices
 {
     /// <summary>
     /// Contains common elements of Project Lab Hardware
     /// </summary>
-    public class ProjectLabHardwareBase : IProjectLabHardware
+    public abstract class ProjectLabHardwareBase : IProjectLabHardware
     {
         protected Logger? Logger { get; } = Resolver.Log;
         protected IF7FeatherMeadowDevice device;
@@ -24,47 +24,47 @@ namespace Meadow.Devices
         /// <summary>
         /// Gets the SPI Bus
         /// </summary>
-        public ISpiBus SpiBus { get; set; }
+        public ISpiBus SpiBus { get; }
         /// <summary>
         /// Gets the I2C Bus
         /// </summary>
-        public II2cBus I2cBus { get; set; }
+        public II2cBus I2cBus { get; }
         /// <summary>
         /// Gets the BH1750 Light Sensor on the Project Lab board
         /// </summary>
-        public Bh1750? LightSensor { get; set; }
+        public Bh1750? LightSensor { get; }
         /// <summary>
         /// Gets the BME688 environmental sensor  on the Project Lab board
         /// </summary>
-        public Bme688? EnvironmentalSensor { get; set; }
+        public Bme688? EnvironmentalSensor { get; }
         /// <summary>
         /// Gets the Piezo noise maker on the Project Lab board
         /// </summary>
-        public PiezoSpeaker? Speaker { get; set; }
+        public PiezoSpeaker? Speaker { get; }
         /// <summary>
         /// Gets the BMI inertial movement unit (IMU) on the Project Lab board
         /// </summary>
-        public Bmi270? MotionSensor { get; set; }
+        public Bmi270? MotionSensor { get; }
         /// <summary>
         /// Gets the ST7789 Display on the Project Lab board
         /// </summary>
-        public St7789? Display { get; set; }
+        public St7789? Display { get; protected set; }
         /// <summary>
         /// Gets the Up PushButton on the Project Lab board
         /// </summary>
-        public PushButton? UpButton { get; set; }
+        public PushButton? UpButton { get; protected set; }
         /// <summary>
         /// Gets the Down PushButton on the Project Lab board
         /// </summary>
-        public PushButton? DownButton { get; set; }
+        public PushButton? DownButton { get; protected set; }
         /// <summary>
         /// Gets the Left PushButton on the Project Lab board
         /// </summary>
-        public PushButton? LeftButton { get; set; }
+        public PushButton? LeftButton { get; protected set; }
         /// <summary>
         /// Gets the Right PushButton on the Project Lab board
         /// </summary>
-        public PushButton? RightButton { get; set; }
+        public PushButton? RightButton { get; protected set; }
         /// <summary>
         /// Gets the ProjectLab board hardware revision
         /// </summary>
@@ -135,11 +135,7 @@ namespace Meadow.Devices
         /// <param name="parity"></param>
         /// <param name="stopBits"></param>
         /// <returns></returns>
-        public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
-        {
-            //return GetModbusRtuClient(baudRate, dataBits, parity, stopBits);
-            throw new Exception("Deal with this.");
-        }
+        public abstract ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One);
 
         /// <summary>
         /// Gets the pin definitions for the Project Lab board

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
@@ -17,7 +17,6 @@ namespace Meadow.Devices
     public abstract class ProjectLabHardwareBase : IProjectLabHardware
     {
         protected Logger? Logger { get; } = Resolver.Log;
-        protected IF7FeatherMeadowDevice device;
 
         //==== properties
 
@@ -48,23 +47,23 @@ namespace Meadow.Devices
         /// <summary>
         /// Gets the ST7789 Display on the Project Lab board
         /// </summary>
-        public St7789? Display { get; protected set; }
+        public abstract St7789? Display { get; }
         /// <summary>
         /// Gets the Up PushButton on the Project Lab board
         /// </summary>
-        public PushButton? UpButton { get; protected set; }
+        public abstract PushButton? UpButton { get; }
         /// <summary>
         /// Gets the Down PushButton on the Project Lab board
         /// </summary>
-        public PushButton? DownButton { get; protected set; }
+        public abstract PushButton? DownButton { get; }
         /// <summary>
         /// Gets the Left PushButton on the Project Lab board
         /// </summary>
-        public PushButton? LeftButton { get; protected set; }
+        public abstract PushButton? LeftButton { get; }
         /// <summary>
         /// Gets the Right PushButton on the Project Lab board
         /// </summary>
-        public PushButton? RightButton { get; protected set; }
+        public abstract PushButton? RightButton { get; }
         /// <summary>
         /// Gets the ProjectLab board hardware revision
         /// </summary>
@@ -72,7 +71,6 @@ namespace Meadow.Devices
 
         public ProjectLabHardwareBase(IF7FeatherMeadowDevice device, ISpiBus spiBus, II2cBus i2cBus)
         {
-            this.device = device;
             this.SpiBus = spiBus;
             this.I2cBus = i2cBus;
 

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
@@ -71,7 +71,7 @@ namespace Meadow.Devices
         /// <summary>
         /// Gets the ProjectLab board hardware revision
         /// </summary>
-        public virtual string RevisionString { get; set; }
+        public virtual string RevisionString { get; set; } = "unknown";
 
         public ProjectLabHardwareBase(IF7FeatherMeadowDevice device, ISpiBus spiBus, II2cBus i2cBus)
         {

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareBase.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using Meadow.Devices;
+using Meadow.Foundation.Audio;
+using Meadow.Foundation.Displays;
+using Meadow.Foundation.ICs.IOExpanders;
+using Meadow.Foundation.Sensors.Accelerometers;
+using Meadow.Foundation.Sensors.Atmospheric;
+using Meadow.Foundation.Sensors.Buttons;
+using Meadow.Foundation.Sensors.Light;
+using Meadow.Hardware;
+using Meadow.Logging;
+using Meadow.Modbus;
+using Meadow.Units;
+
+namespace Meadow.Devices
+{
+    /// <summary>
+    /// Contains common elements of Project Lab Hardware
+    /// </summary>
+    public class ProjectLabHardwareBase : IProjectLabHardware
+    {
+        protected Logger? Logger { get; } = Resolver.Log;
+        protected IF7FeatherMeadowDevice device;
+
+        //==== properties
+
+        /// <summary>
+        /// Gets the SPI Bus
+        /// </summary>
+        public ISpiBus SpiBus { get; set; }
+        /// <summary>
+        /// Gets the I2C Bus
+        /// </summary>
+        public II2cBus I2cBus { get; set; }
+        /// <summary>
+        /// Gets the BH1750 Light Sensor on the Project Lab board
+        /// </summary>
+        public Bh1750? LightSensor { get; set; }
+        /// <summary>
+        /// Gets the BME688 environmental sensor  on the Project Lab board
+        /// </summary>
+        public Bme688? EnvironmentalSensor { get; set; }
+        /// <summary>
+        /// Gets the Piezo noise maker on the Project Lab board
+        /// </summary>
+        public PiezoSpeaker? Speaker { get; set; }
+        /// <summary>
+        /// Gets the BMI inertial movement unit (IMU) on the Project Lab board
+        /// </summary>
+        public Bmi270? MotionSensor { get; set; }
+        /// <summary>
+        /// Gets the ST7789 Display on the Project Lab board
+        /// </summary>
+        public St7789? Display { get; set; }
+        /// <summary>
+        /// Gets the Up PushButton on the Project Lab board
+        /// </summary>
+        public PushButton? UpButton { get; set; }
+        /// <summary>
+        /// Gets the Down PushButton on the Project Lab board
+        /// </summary>
+        public PushButton? DownButton { get; set; }
+        /// <summary>
+        /// Gets the Left PushButton on the Project Lab board
+        /// </summary>
+        public PushButton? LeftButton { get; set; }
+        /// <summary>
+        /// Gets the Right PushButton on the Project Lab board
+        /// </summary>
+        public PushButton? RightButton { get; set; }
+        /// <summary>
+        /// Gets the ProjectLab board hardware revision
+        /// </summary>
+        public virtual string RevisionString { get; set; }
+
+        public ProjectLabHardwareBase(IF7FeatherMeadowDevice device, ISpiBus spiBus, II2cBus i2cBus)
+        {
+            this.device = device;
+            this.SpiBus = spiBus;
+            this.I2cBus = i2cBus;
+
+            //==== Initialize the shared/common stuff
+            try
+            {
+                Logger?.Info("Instantiating light sensor.");
+                LightSensor = new Bh1750(
+                    i2cBus: I2cBus,
+                    measuringMode: Bh1750.MeasuringModes.ContinuouslyHighResolutionMode, // the various modes take differing amounts of time.
+                    lightTransmittance: 0.5, // lower this to increase sensitivity, for instance, if it's behind a semi opaque window
+                    address: (byte)Bh1750.Addresses.Address_0x23);
+                Logger?.Info("Light sensor up.");
+            }
+            catch (Exception ex)
+            {
+                Resolver.Log.Error($"Unable to create the BH1750 Light Sensor: {ex.Message}");
+            }
+
+            try
+            {
+                Logger?.Info("Instantiating environmental sensor.");
+                EnvironmentalSensor = new Bme688(I2cBus, (byte)Bme688.Addresses.Address_0x76);
+                Logger?.Info("Environmental sensor up.");
+            }
+            catch (Exception ex)
+            {
+                Resolver.Log.Error($"Unable to create the BME688 Environmental Sensor: {ex.Message}");
+            }
+
+            try
+            {
+                Logger?.Info("Instantiating speaker.");
+                Speaker = new PiezoSpeaker(device, device.Pins.D11);
+                Logger?.Info("Speaker up.");
+            }
+            catch (Exception ex)
+            {
+                Resolver.Log.Error($"Unable to create the Piezo Speaker: {ex.Message}");
+            }
+
+            try
+            {
+                Logger?.Info("Instantiating motion sensor.");
+                MotionSensor = new Bmi270(I2cBus);
+                Logger?.Info("Motion sensor up.");
+            }
+            catch (Exception ex)
+            {
+                Resolver.Log.Error($"Unable to create the BMI270 IMU: {ex.Message}");
+            }
+
+        }
+
+        /// <summary>
+        /// Gets a ModbusRtuClient for the on-baord RS485 connector
+        /// </summary>
+        /// <param name="baudRate"></param>
+        /// <param name="dataBits"></param>
+        /// <param name="parity"></param>
+        /// <param name="stopBits"></param>
+        /// <returns></returns>
+        public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
+        {
+            //return GetModbusRtuClient(baudRate, dataBits, parity, stopBits);
+            throw new Exception("Deal with this.");
+        }
+
+        /// <summary>
+        /// Gets the pin definitions for the Project Lab board
+        /// </summary>
+        public static (
+            IPin MB1_CS,
+            IPin MB1_INT,
+            IPin MB1_PWM,
+            IPin MB1_AN,
+            IPin MB1_SO,
+            IPin MB1_SI,
+            IPin MB1_SCK,
+            IPin MB1_SCL,
+            IPin MB1_SDA,
+
+            IPin MB2_CS,
+            IPin MB2_INT,
+            IPin MB2_PWM,
+            IPin MB2_AN,
+            IPin MB2_SO,
+            IPin MB2_SI,
+            IPin MB2_SCK,
+            IPin MB2_SCL,
+            IPin MB2_SDA,
+
+            IPin A0,
+            IPin D03,
+            IPin D04
+            ) Pins = (
+            Resolver.Device.GetPin("D14"),
+            Resolver.Device.GetPin("D03"),
+            Resolver.Device.GetPin("D04"),
+            Resolver.Device.GetPin("A00"),
+            Resolver.Device.GetPin("CIPO"),
+            Resolver.Device.GetPin("COPI"),
+            Resolver.Device.GetPin("SCK"),
+            Resolver.Device.GetPin("D08"),
+            Resolver.Device.GetPin("D07"),
+
+            Resolver.Device.GetPin("A02"),
+            Resolver.Device.GetPin("D04"),
+            Resolver.Device.GetPin("D03"),
+            Resolver.Device.GetPin("A01"),
+            Resolver.Device.GetPin("CIPO"),
+            Resolver.Device.GetPin("COPI"),
+            Resolver.Device.GetPin("SCK"),
+            Resolver.Device.GetPin("D08"),
+            Resolver.Device.GetPin("D07"),
+
+            Resolver.Device.GetPin("A00"),
+            Resolver.Device.GetPin("D03"),
+            Resolver.Device.GetPin("D04")
+            );
+    }
+}
+

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
@@ -1,13 +1,6 @@
-﻿using Meadow;
-using Meadow.Devices;
-using Meadow.Foundation.Audio;
-using Meadow.Foundation.Displays;
+﻿using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
-using Meadow.Foundation.Sensors.Accelerometers;
-using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
-using Meadow.Foundation.Sensors.Light;
-using Meadow.Gateways.Bluetooth;
 using Meadow.Hardware;
 using Meadow.Modbus;
 using System;
@@ -57,7 +50,7 @@ namespace Meadow.Devices
                     ResistorMode.InternalPullDown));
         }
 
-        public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
+        public override ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
         {
             if (Resolver.Device is F7FeatherV1 device)
             {

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
@@ -1,50 +1,52 @@
-﻿using Meadow.Foundation.Displays;
+﻿using Meadow;
+using Meadow.Devices;
+using Meadow.Foundation.Audio;
+using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
+using Meadow.Foundation.Sensors.Accelerometers;
+using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
+using Meadow.Foundation.Sensors.Light;
+using Meadow.Gateways.Bluetooth;
 using Meadow.Hardware;
 using Meadow.Modbus;
 using System;
 
 namespace Meadow.Devices
 {
-    internal class ProjectLabHardwareV1 : IProjectLabHardware
+    internal class ProjectLabHardwareV1 : ProjectLabHardwareBase
     {
-        private IF7FeatherMeadowDevice device;
-        private ISpiBus spiBus;
-        private St7789? display;
-        private PushButton? rightButton;
-        private PushButton? leftButton;
-        private PushButton? upButton;
-        private PushButton? downButton;
         private string revision = "v1.x";
 
-        public ProjectLabHardwareV1(IF7FeatherMeadowDevice device, ISpiBus spiBus)
+        public ProjectLabHardwareV1(IF7FeatherMeadowDevice device, ISpiBus spiBus, II2cBus i2cBus)
+            : base(device, spiBus, i2cBus)
         {
-            this.device = device;
-            this.spiBus = spiBus;
+            
         }
 
-        public string GetRevisionString()
-        {
-            return revision;
-        }
+        public override string RevisionString => revision;
 
-        public St7789 GetDisplay()
+        public St7789 Display
         {
-            if (display == null)
+            get
             {
-                display = new St7789(
-                    device: device,
-                    spiBus: spiBus,
-                    chipSelectPin: device.Pins.A03,
-                    dcPin: device.Pins.A04,
-                    resetPin: device.Pins.A05,
-                    width: 240, height: 240,
-                    colorMode: ColorType.Format16bppRgb565);
-            }
+                if (display == null)
+                {
+                    display = new St7789(
+                        device: device,
+                        spiBus: SpiBus,
+                        chipSelectPin: device.Pins.A03,
+                        dcPin: device.Pins.A04,
+                        resetPin: device.Pins.A05,
+                        width: 240, height: 240,
+                        colorMode: ColorType.Format16bppRgb565);
+                }
 
-            return display;
+                return display;
+            }
+            set { throw new Exception("Don't set this."); }
         }
+        protected St7789 display;
 
         private PushButton GetPushButton(IF7FeatherMeadowDevice device, IPin pin, InterruptMode? interruptMode = null)
         {
@@ -60,49 +62,61 @@ namespace Meadow.Devices
                     ResistorMode.InternalPullDown));
         }
 
-        public PushButton GetLeftButton()
+        public PushButton LeftButton
         {
-            if (leftButton == null)
+            get
             {
-                leftButton = GetPushButton(device, device.Pins.D10);
-            }
-            return leftButton;
-        }
-
-        public PushButton GetRightButton()
-        {
-            if (rightButton == null)
-            {
-                rightButton = GetPushButton(device, device.Pins.D05);
-            }
-            return rightButton;
-        }
-
-        public PushButton GetUpButton()
-        {
-            if (upButton == null)
-            {
-                upButton = GetPushButton(device, device.Pins.D15);
-            }
-            return upButton;
-        }
-
-        public PushButton GetDownButton()
-        {
-            if (downButton == null)
-            {
-                if (device is F7FeatherV1)
+                if (leftButton == null)
                 {
-                    // timer conflict with piezo?
-                    downButton = GetPushButton(device, device.Pins.D02, InterruptMode.None);
+                    leftButton = GetPushButton(device, device.Pins.D10);
                 }
-                else
+                return leftButton;
+            }
+            set { throw new Exception("Don't set this."); }
+        }
+        protected PushButton leftButton;
+
+        public PushButton RightButton
+        {
+            get
+            {
+                if (rightButton == null)
+                {
+                    rightButton = GetPushButton(device, device.Pins.D05);
+                }
+                return rightButton;
+            }
+            set { throw new Exception("Don't set this."); }
+        }
+        protected PushButton rightButton;
+
+        public PushButton UpButton
+        {
+            get
+            {
+                if (upButton == null)
+                {
+                    upButton = GetPushButton(device, device.Pins.D15);
+                }
+                return upButton;
+            }
+            set { throw new Exception("Don't set this."); }
+        }
+        protected PushButton upButton;
+
+        public PushButton DownButton
+        {
+            get
+            {
+                if (downButton == null)
                 {
                     downButton = GetPushButton(device, device.Pins.D02);
                 }
+                return downButton;
             }
-            return downButton;
+            set { throw new Exception("Don't set this."); }
         }
+        protected PushButton downButton;
 
         public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
         {

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
@@ -21,18 +21,9 @@ namespace Meadow.Devices
         public ProjectLabHardwareV1(IF7FeatherMeadowDevice device, ISpiBus spiBus, II2cBus i2cBus)
             : base(device, spiBus, i2cBus)
         {
-            
-        }
-
-        public override string RevisionString => revision;
-
-        public St7789 Display
-        {
-            get
-            {
-                if (display == null)
-                {
-                    display = new St7789(
+            //---- create our display
+            Logger?.Info("Instantiating display.");
+            base.Display = new St7789(
                         device: device,
                         spiBus: SpiBus,
                         chipSelectPin: device.Pins.A03,
@@ -40,13 +31,17 @@ namespace Meadow.Devices
                         resetPin: device.Pins.A05,
                         width: 240, height: 240,
                         colorMode: ColorType.Format16bppRgb565);
-                }
 
-                return display;
-            }
-            set { throw new Exception("Don't set this."); }
+            //---- buttons
+            Logger?.Info("Instantiating buttons.");
+            LeftButton = GetPushButton(device, device.Pins.D10);
+            RightButton = GetPushButton(device, device.Pins.D05);
+            UpButton = GetPushButton(device, device.Pins.D15);
+            DownButton = GetPushButton(device, device.Pins.D02);
+            Logger?.Info("Buttons up.");
         }
-        protected St7789 display;
+
+        public override string RevisionString => revision;
 
         private PushButton GetPushButton(IF7FeatherMeadowDevice device, IPin pin, InterruptMode? interruptMode = null)
         {
@@ -61,62 +56,6 @@ namespace Meadow.Devices
                     interruptMode.Value,
                     ResistorMode.InternalPullDown));
         }
-
-        public PushButton LeftButton
-        {
-            get
-            {
-                if (leftButton == null)
-                {
-                    leftButton = GetPushButton(device, device.Pins.D10);
-                }
-                return leftButton;
-            }
-            set { throw new Exception("Don't set this."); }
-        }
-        protected PushButton leftButton;
-
-        public PushButton RightButton
-        {
-            get
-            {
-                if (rightButton == null)
-                {
-                    rightButton = GetPushButton(device, device.Pins.D05);
-                }
-                return rightButton;
-            }
-            set { throw new Exception("Don't set this."); }
-        }
-        protected PushButton rightButton;
-
-        public PushButton UpButton
-        {
-            get
-            {
-                if (upButton == null)
-                {
-                    upButton = GetPushButton(device, device.Pins.D15);
-                }
-                return upButton;
-            }
-            set { throw new Exception("Don't set this."); }
-        }
-        protected PushButton upButton;
-
-        public PushButton DownButton
-        {
-            get
-            {
-                if (downButton == null)
-                {
-                    downButton = GetPushButton(device, device.Pins.D02);
-                }
-                return downButton;
-            }
-            set { throw new Exception("Don't set this."); }
-        }
-        protected PushButton downButton;
 
         public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
         {

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV1.cs
@@ -11,12 +11,33 @@ namespace Meadow.Devices
     {
         private string revision = "v1.x";
 
+        /// <summary>
+        /// Gets the ST7789 Display on the Project Lab board
+        /// </summary>
+        public override St7789? Display { get; }
+        /// <summary>
+        /// Gets the Up PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? UpButton { get; }
+        /// <summary>
+        /// Gets the Down PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? DownButton { get; }
+        /// <summary>
+        /// Gets the Left PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? LeftButton { get; }
+        /// <summary>
+        /// Gets the Right PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? RightButton { get; }
+
         public ProjectLabHardwareV1(IF7FeatherMeadowDevice device, ISpiBus spiBus, II2cBus i2cBus)
             : base(device, spiBus, i2cBus)
         {
             //---- create our display
             Logger?.Info("Instantiating display.");
-            base.Display = new St7789(
+            Display = new St7789(
                         device: device,
                         spiBus: SpiBus,
                         chipSelectPin: device.Pins.A03,

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
@@ -1,117 +1,147 @@
-﻿using Meadow.Foundation.Displays;
+﻿using Meadow.Foundation.Audio;
+using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
 using Meadow.Foundation.ICs.IOExpanders;
+using Meadow.Foundation.Sensors.Accelerometers;
+using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
+using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
+using Meadow.Logging;
 using Meadow.Modbus;
 using System;
 using System.Threading;
 
 namespace Meadow.Devices
 {
-    internal class ProjectLabHardwareV2 : IProjectLabHardware
+    internal class ProjectLabHardwareV2 : ProjectLabHardwareBase
     {
-        private IF7FeatherMeadowDevice device;
-        private ISpiBus spiBus;
-        private Mcp23008 mcp1;
-        private Mcp23008 mcp2;
-        private Mcp23008? mcpVersion;
+        protected Mcp23008 mcp1;
+        protected Mcp23008 mcp2;
+        protected Mcp23008? mcpVersion;
 
-        private St7789? display;
-        private PushButton? leftButton;
-        private PushButton? rightButton;
-        private PushButton? upButton;
-        private PushButton? downButton;
-        private string? revision;
-
-        public ProjectLabHardwareV2(Mcp23008 mcp1, Mcp23008 mcp2, Mcp23008? mcpVersion, IF7FeatherMeadowDevice device, ISpiBus spiBus)
+        public ProjectLabHardwareV2(
+            IF7FeatherMeadowDevice device,
+            ISpiBus spiBus,
+            II2cBus i2cBus,
+            Mcp23008 mcp1, Mcp23008 mcp2, Mcp23008? mcpVersion
+            ) : base (device, spiBus, i2cBus )
         {
-            this.device = device;
-            this.spiBus = spiBus;
             this.mcp1 = mcp1;
             this.mcp2 = mcp2;
             this.mcpVersion = mcpVersion;
         }
 
-        public string GetRevisionString()
+        public override string RevisionString
         {
-            // TODO: figure this out from MCP3?
-            if (revision == null)
+            get
             {
-                if (mcpVersion == null)
+                // TODO: figure this out from MCP3?
+                if (revision == null)
                 {
-                    revision = $"v2.x";
+                    if (mcpVersion == null)
+                    {
+                        revision = $"v2.x";
+                    }
+                    else
+                    {
+                        byte rev = mcpVersion.ReadFromPorts(Mcp23xxx.PortBank.A);
+                        //mapping? 0 == d2.d?
+                        revision = $"v2.{rev}";
+                    }
                 }
-                else
+                return revision;
+            }
+        }
+        protected string? revision;
+
+        public St7789 Display
+        {
+            get
+            {
+                if (display == null)
                 {
-                    byte rev = mcpVersion.ReadFromPorts(Mcp23xxx.PortBank.A);
-                    //mapping? 0 == d2.d?
-                    revision = $"v2.{rev}";
+                    Logger?.Info("Instantiating display.");
+                    var chipSelectPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP5);
+                    var dcPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP6);
+                    var resetPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP7);
+
+                    Thread.Sleep(50);
+
+                    display = new St7789(
+                        spiBus: SpiBus,
+                        chipSelectPort: chipSelectPort,
+                        dataCommandPort: dcPort,
+                        resetPort: resetPort,
+                        width: 240, height: 240,
+                        colorMode: ColorType.Format16bppRgb565);
+                    Logger?.Info("Display up.");
                 }
+                return display;
             }
-            return revision;
+            set { display = value; }
         }
+        protected St7789? display;
 
-        public St7789 GetDisplay()
+        public PushButton LeftButton
         {
-            if (display == null)
+            get
             {
-                var chipSelectPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP5);
-                var dcPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP6);
-                var resetPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP7);
-
-                Thread.Sleep(50);
-
-                display = new St7789(
-                    spiBus: spiBus,
-                    chipSelectPort: chipSelectPort,
-                    dataCommandPort: dcPort,
-                    resetPort: resetPort,
-                    width: 240, height: 240,
-                    colorMode: ColorType.Format16bppRgb565);
+                if (leftButton == null)
+                {
+                    var leftPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP2, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    leftButton = new PushButton(leftPort);
+                }
+                return leftButton;
             }
-            return display;
+            set { throw new Exception("Don't set this."); }
         }
+        protected PushButton? leftButton;
 
-        public PushButton GetLeftButton()
+        public PushButton RightButton
         {
-            if (leftButton == null)
+            get
             {
-                var leftPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP2, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                leftButton = new PushButton(leftPort);
+                if (rightButton == null)
+                {
+                    var rightPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP1, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    rightButton = new PushButton(rightPort);
+                }
+                return rightButton;
             }
-            return leftButton;
+            set { throw new Exception("Don't set this."); }
         }
+        protected PushButton? rightButton;
 
-        public PushButton GetRightButton()
+        public PushButton UpButton
         {
-            if (rightButton == null)
+            get
             {
-                var rightPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP1, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                rightButton = new PushButton(rightPort);
+                if (upButton == null)
+                {
+                    var upPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP0, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    upButton = new PushButton(upPort);
+                }
+                return upButton;
             }
-            return rightButton;
+            set { throw new Exception("Don't set this."); }
         }
+        protected PushButton? upButton;
 
-        public PushButton GetUpButton()
+        public PushButton DownButton
         {
-            if (upButton == null)
+            get
             {
-                var upPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP0, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                upButton = new PushButton(upPort);
+                if (downButton == null)
+                {
+                    var downPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP3, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
+                    downButton = new PushButton(downPort);
+                }
+                return downButton;
             }
-            return upButton;
+            set { throw new Exception("Don't set this."); }
         }
-
-        public PushButton GetDownButton()
-        {
-            if (downButton == null)
-            {
-                var downPort = mcp1.CreateDigitalInputPort(mcp1.Pins.GP3, InterruptMode.EdgeBoth, ResistorMode.InternalPullUp);
-                downButton = new PushButton(downPort);
-            }
-            return downButton;
-        }
+        protected PushButton? downButton;
 
         public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
         {

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
@@ -1,17 +1,11 @@
-﻿using Meadow.Foundation.Audio;
+﻿using System;
+using System.Threading;
 using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
 using Meadow.Foundation.ICs.IOExpanders;
-using Meadow.Foundation.Sensors.Accelerometers;
-using Meadow.Foundation.Sensors.Atmospheric;
 using Meadow.Foundation.Sensors.Buttons;
-using Meadow.Foundation.Sensors.Light;
 using Meadow.Hardware;
-using Meadow.Logging;
 using Meadow.Modbus;
-using Meadow.Peripherals.Displays;
-using System;
-using System.Threading;
 
 namespace Meadow.Devices
 {

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
@@ -11,9 +11,30 @@ namespace Meadow.Devices
 {
     internal class ProjectLabHardwareV2 : ProjectLabHardwareBase
     {
-        protected Mcp23008 mcp1;
-        protected Mcp23008 mcp2;
-        protected Mcp23008? mcpVersion;
+        private Mcp23008 mcp1;
+        private Mcp23008 mcp2;
+        private Mcp23008? mcpVersion;
+
+        /// <summary>
+        /// Gets the ST7789 Display on the Project Lab board
+        /// </summary>
+        public override St7789? Display { get; }
+        /// <summary>
+        /// Gets the Up PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? UpButton { get; }
+        /// <summary>
+        /// Gets the Down PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? DownButton { get; }
+        /// <summary>
+        /// Gets the Left PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? LeftButton { get; }
+        /// <summary>
+        /// Gets the Right PushButton on the Project Lab board
+        /// </summary>
+        public override PushButton? RightButton { get; }
 
         public ProjectLabHardwareV2(
             IF7FeatherMeadowDevice device,
@@ -33,7 +54,7 @@ namespace Meadow.Devices
             var resetPort = mcp1.CreateDigitalOutputPort(mcp1.Pins.GP7);
             Thread.Sleep(50);
 
-            base.Display = new St7789(
+            Display = new St7789(
                 spiBus: SpiBus,
                 chipSelectPort: chipSelectPort,
                 dataCommandPort: dcPort,

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Threading;
-using Meadow.Foundation.Displays;
+﻿using Meadow.Foundation.Displays;
 using Meadow.Foundation.Graphics;
 using Meadow.Foundation.ICs.IOExpanders;
 using Meadow.Foundation.Sensors.Buttons;
 using Meadow.Hardware;
 using Meadow.Modbus;
+using System;
+using System.Threading;
 
 namespace Meadow.Devices
 {
@@ -20,7 +20,7 @@ namespace Meadow.Devices
             ISpiBus spiBus,
             II2cBus i2cBus,
             Mcp23008 mcp1, Mcp23008 mcp2, Mcp23008? mcpVersion
-            ) : base (device, spiBus, i2cBus )
+            ) : base(device, spiBus, i2cBus)
         {
             this.mcp1 = mcp1;
             this.mcp2 = mcp2;
@@ -78,7 +78,7 @@ namespace Meadow.Devices
         }
         protected string? revision;
 
-        public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
+        public override ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
         {
             if (Resolver.Device is F7FeatherV2 device)
             {

--- a/Source/ProjectLab_Demo/MeadowApp.cs
+++ b/Source/ProjectLab_Demo/MeadowApp.cs
@@ -1,6 +1,8 @@
 ﻿using Meadow;
 using Meadow.Devices;
 using Meadow.Foundation;
+using Meadow.Foundation.Leds;
+using Meadow.Peripherals.Leds;
 using Meadow.Units;
 using System;
 using System.Threading.Tasks;
@@ -8,69 +10,76 @@ using System.Threading.Tasks;
 namespace ProjLab_Demo
 {
     // Change F7FeatherV2 to F7FeatherV1 for V1.x boards
-    public class MeadowApp : App<F7FeatherV1>
+    public class MeadowApp : App<F7FeatherV2>
     {
         DisplayController displayController;
+        RgbPwmLed onboardLed;
         ProjectLab projLab;
 
         public override Task Initialize()
         {
             Console.WriteLine("Initialize hardware...");
 
+            //==== RGB LED
+            Resolver.Log.Info("Initializing onboard RGB LED.");
+            onboardLed = new RgbPwmLed(device: Device,
+                redPwmPin: Device.Pins.OnboardLedRed,
+                greenPwmPin: Device.Pins.OnboardLedGreen,
+                bluePwmPin: Device.Pins.OnboardLedBlue,
+                CommonType.CommonAnode);
+            Resolver.Log.Info("RGB LED up.");
+
             projLab = new ProjectLab();
 
-            Resolver.Log.Info($"Running on ProjectLab Hardware {projLab.HardwareRevision}");
+            Resolver.Log.Info($"Running on ProjectLab Hardware {projLab.Hardware.RevisionString}");
 
-            if (projLab.Display is { } display)
+            if (projLab.Hardware.Display is { } display)
             {
                 displayController = new DisplayController(display, projLab.IsV1Hardware());
             }
 
             //---- BH1750 Light Sensor
-            if (projLab.LightSensor is { } bh1750)
+            if (projLab.Hardware.LightSensor is { } bh1750)
             {
                 Resolver.Log.Info($"Light sensor created");
                 bh1750.Updated += Bh1750Updated;
-                bh1750.StartUpdating(TimeSpan.FromSeconds(5));
             }
 
             //---- BME688 Atmospheric sensor
-            if (projLab.EnvironmentalSensor is { } bme688)
+            if (projLab.Hardware.EnvironmentalSensor is { } bme688)
             {
                 Resolver.Log.Info($"Environmental sensor created");
                 bme688.Updated += Bme688Updated;
-                bme688.StartUpdating(TimeSpan.FromSeconds(5));
             }
 
             //---- BMI270 Accel/IMU
-            if (projLab.MotionSensor is { } bmi270)
+            if (projLab.Hardware.MotionSensor is { } bmi270)
             {
                 Resolver.Log.Info($"IMU created");
                 bmi270.Updated += Bmi270Updated;
-                bmi270.StartUpdating(TimeSpan.FromSeconds(5));
             }
 
             //---- buttons
-            if (projLab.RightButton is { } rightButton)
+            if (projLab.Hardware.RightButton is { } rightButton)
             {
                 Resolver.Log.Info($"Right button created");
                 rightButton.PressStarted += (s, e) => displayController.RightButtonState = true;
                 rightButton.PressEnded += (s, e) => displayController.RightButtonState = false;
             }
 
-            if (projLab.DownButton is { } downButton)
+            if (projLab.Hardware.DownButton is { } downButton)
             {
                 Resolver.Log.Info($"Down button created");
                 downButton.PressStarted += (s, e) => displayController.DownButtonState = true;
                 downButton.PressEnded += (s, e) => displayController.DownButtonState = false;
             }
-            if (projLab.LeftButton is { } leftButton)
+            if (projLab.Hardware.LeftButton is { } leftButton)
             {
                 Resolver.Log.Info($"Left button created");
                 leftButton.PressStarted += (s, e) => displayController.LeftButtonState = true;
                 leftButton.PressEnded += (s, e) => displayController.LeftButtonState = false;
             }
-            if (projLab.UpButton is { } upButton)
+            if (projLab.Hardware.UpButton is { } upButton)
             {
                 Resolver.Log.Info($"Up button created");
                 upButton.PressStarted += (s, e) => displayController.UpButtonState = true;
@@ -78,12 +87,46 @@ namespace ProjLab_Demo
             }
 
             //---- heartbeat
-            projLab.Led.StartPulse(WildernessLabsColors.PearGreen);
+            onboardLed.StartPulse(WildernessLabsColors.PearGreen);
 
             Console.WriteLine("Initialization complete");
 
             return base.Initialize();
         }
+
+        public override Task Run()
+        {
+            Console.WriteLine("Run...");
+
+            //---- BH1750 Light Sensor
+            if (projLab.Hardware.LightSensor is { } bh1750)
+            {
+                bh1750.StartUpdating(TimeSpan.FromSeconds(5));
+            }
+
+            //---- BME688 Atmospheric sensor
+            if (projLab.Hardware.EnvironmentalSensor is { } bme688)
+            {
+                bme688.StartUpdating(TimeSpan.FromSeconds(5));
+            }
+
+            //---- BMI270 Accel/IMU
+            if (projLab.Hardware.MotionSensor is { } bmi270)
+            {
+                bmi270.StartUpdating(TimeSpan.FromSeconds(5));
+            }
+
+            if (displayController != null)
+            {
+                displayController.Update();
+            }
+
+            Console.WriteLine("starting blink");
+            onboardLed.StartBlink(WildernessLabsColors.PearGreen, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(2000), 0.5f);
+
+            return base.Run();
+        }
+
 
         private void Bmi270Updated(object sender, IChangeResult<(Acceleration3D? Acceleration3D, AngularVelocity3D? AngularVelocity3D, Temperature? Temperature)> e)
         {
@@ -110,21 +153,6 @@ namespace ProjLab_Demo
             {
                 displayController.LightConditions = e.New;
             }
-        }
-
-        public override Task Run()
-        {
-            Console.WriteLine("Run...");
-
-            if (displayController != null)
-            {
-                displayController.Update();
-            }
-
-            Console.WriteLine("starting blink");
-            projLab.Led.StartBlink(WildernessLabsColors.PearGreen, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(2000), 0.5f);
-
-            return base.Run();
         }
     }
 }

--- a/Source/ProjectLab_Demo/MeadowApp.cs
+++ b/Source/ProjectLab_Demo/MeadowApp.cs
@@ -1,11 +1,11 @@
-﻿using Meadow;
+﻿using System;
+using System.Threading.Tasks;
+using Meadow;
 using Meadow.Devices;
 using Meadow.Foundation;
 using Meadow.Foundation.Leds;
 using Meadow.Peripherals.Leds;
 using Meadow.Units;
-using System;
-using System.Threading.Tasks;
 
 namespace ProjLab_Demo
 {

--- a/Source/ProjectLab_Demo/MeadowApp.cs
+++ b/Source/ProjectLab_Demo/MeadowApp.cs
@@ -29,59 +29,56 @@ namespace ProjLab_Demo
                 CommonType.CommonAnode);
             Resolver.Log.Info("RGB LED up.");
 
+            //==== instantiate the project lab hardware
             projLab = new ProjectLab();
 
             Resolver.Log.Info($"Running on ProjectLab Hardware {projLab.Hardware.RevisionString}");
 
+            //---- display controller (handles display updates)
             if (projLab.Hardware.Display is { } display)
             {
+                Resolver.Log.Info("Creating DisplayController.");
                 displayController = new DisplayController(display, projLab.IsV1Hardware());
+                Resolver.Log.Info("DisplayController up.");
             }
 
             //---- BH1750 Light Sensor
             if (projLab.Hardware.LightSensor is { } bh1750)
             {
-                Resolver.Log.Info($"Light sensor created");
                 bh1750.Updated += Bh1750Updated;
             }
 
             //---- BME688 Atmospheric sensor
             if (projLab.Hardware.EnvironmentalSensor is { } bme688)
             {
-                Resolver.Log.Info($"Environmental sensor created");
                 bme688.Updated += Bme688Updated;
             }
 
             //---- BMI270 Accel/IMU
             if (projLab.Hardware.MotionSensor is { } bmi270)
             {
-                Resolver.Log.Info($"IMU created");
                 bmi270.Updated += Bmi270Updated;
             }
 
             //---- buttons
             if (projLab.Hardware.RightButton is { } rightButton)
             {
-                Resolver.Log.Info($"Right button created");
                 rightButton.PressStarted += (s, e) => displayController.RightButtonState = true;
                 rightButton.PressEnded += (s, e) => displayController.RightButtonState = false;
             }
 
             if (projLab.Hardware.DownButton is { } downButton)
             {
-                Resolver.Log.Info($"Down button created");
                 downButton.PressStarted += (s, e) => displayController.DownButtonState = true;
                 downButton.PressEnded += (s, e) => displayController.DownButtonState = false;
             }
             if (projLab.Hardware.LeftButton is { } leftButton)
             {
-                Resolver.Log.Info($"Left button created");
                 leftButton.PressStarted += (s, e) => displayController.LeftButtonState = true;
                 leftButton.PressEnded += (s, e) => displayController.LeftButtonState = false;
             }
             if (projLab.Hardware.UpButton is { } upButton)
             {
-                Resolver.Log.Info($"Up button created");
                 upButton.PressStarted += (s, e) => displayController.UpButtonState = true;
                 upButton.PressEnded += (s, e) => displayController.UpButtonState = false;
             }
@@ -130,7 +127,7 @@ namespace ProjLab_Demo
 
         private void Bmi270Updated(object sender, IChangeResult<(Acceleration3D? Acceleration3D, AngularVelocity3D? AngularVelocity3D, Temperature? Temperature)> e)
         {
-            Console.WriteLine($"BMI270: {e.New.Acceleration3D.Value.X.Gravity:0.0},{e.New.Acceleration3D.Value.Y.Gravity:0.0},{e.New.Acceleration3D.Value.Z.Gravity:0.0}g");
+            Resolver.Log.Info($"BMI270: {e.New.Acceleration3D.Value.X.Gravity:0.0},{e.New.Acceleration3D.Value.Y.Gravity:0.0},{e.New.Acceleration3D.Value.Z.Gravity:0.0}g");
             if (displayController != null)
             {
                 displayController.AccelerationConditions = e.New;
@@ -139,7 +136,7 @@ namespace ProjLab_Demo
 
         private void Bme688Updated(object sender, IChangeResult<(Temperature? Temperature, RelativeHumidity? Humidity, Pressure? Pressure, Resistance? GasResistance)> e)
         {
-            Console.WriteLine($"BME688: {(int)e.New.Temperature?.Celsius}°C - {(int)e.New.Humidity?.Percent}% - {(int)e.New.Pressure?.Millibar}mbar");
+            Resolver.Log.Info($"BME688: {(int)e.New.Temperature?.Celsius}°C - {(int)e.New.Humidity?.Percent}% - {(int)e.New.Pressure?.Millibar}mbar");
             if (displayController != null)
             {
                 displayController.AtmosphericConditions = e.New;
@@ -148,7 +145,7 @@ namespace ProjLab_Demo
 
         private void Bh1750Updated(object sender, IChangeResult<Illuminance> e)
         {
-            Console.WriteLine($"BH1750: {e.New.Lux}");
+            Resolver.Log.Info($"BH1750: {e.New.Lux}");
             if (displayController != null)
             {
                 displayController.LightConditions = e.New;


### PR DESCRIPTION
I took a whack at cleaning up the architecture here. I think this is much cleaner and easier to understand. It's also a whole lot less code.

# Changes

 * The `IProjectLabHardware` interface is now public so it can be extended by consumers
 * There is now a `ProjectLabHardwareBase` class that handles a lot of the shared stuff
 * I removed the `Lazy<T>` stuff. I don't think it added any value and it massively complicated the code. 
 * I removed the `OnboardLed` from the hardware. A future revision of the Project Lab board will likely be based off the CCM, where there is no onboard LED.

# Remaining Questions + Work

 * I left `GetModbusRtuClient()` unchanged. i'd love to understand more about this, i believe there may be some additional simplification here.

# Testing

* I tested this as working on a Project Lab v2 board with an F7v2. I don't have any other hardware with me.