### PR TITLE
rearchitected the project lab class to use the factory pattern to create the hardware

### DIFF
--- a/Source/Meadow.ProjectLab/ProjectLab.cs
+++ b/Source/Meadow.ProjectLab/ProjectLab.cs
@@ -13,66 +13,58 @@ using System;
 
 namespace Meadow.Devices
 {
-    public class ProjectLab : IProjectLabHardware
+    public class ProjectLab
     {
-        protected Logger? Logger { get; } = Resolver.Log;
-        protected IProjectLabHardware Hardware { get; set; }
-
-        public II2cBus I2cBus { get; protected set; }
-        public ISpiBus SpiBus { get; protected set; }
-        public St7789? Display => Hardware.Display;
-        public Bh1750? LightSensor => Hardware.LightSensor;
-        public Bme688? EnvironmentalSensor => Hardware.EnvironmentalSensor;
-        public Bmi270? MotionSensor => Hardware.MotionSensor;
-        public PiezoSpeaker? Speaker => Hardware.Speaker;
-        public PushButton? LeftButton => Hardware.LeftButton;
-        public PushButton? RightButton => Hardware.RightButton;
-        public PushButton? UpButton => Hardware.UpButton;
-        public PushButton? DownButton => Hardware.DownButton;
-        public string RevisionString => Hardware.RevisionString;
+        private ProjectLab() { }
 
         /// <summary>
         /// Create an instance of the ProjectLab class
         /// </summary>
+        /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public ProjectLab()
+        public static IProjectLabHardware CreateProjectLab()
         {
+            IProjectLabHardware hardware;
+            Logger? logger = Resolver.Log;
+            II2cBus i2cBus;
+            ISpiBus spiBus;
+
             // v2+ stuff
             Mcp23008? mcp_1 = null;
 
-            Logger?.Debug("Initializing Project Lab...");
+            logger?.Debug("Initializing Project Lab...");
 
             // make sure not getting instantiated before the App Initialize method
             if (Resolver.Device == null)
             {
                 var msg = "ProjLab instance must be created no earlier than App.Initialize()";
-                Logger?.Error(msg);
+                logger?.Error(msg);
                 throw new Exception(msg);
             }
 
             if (!(Resolver.Device is IF7FeatherMeadowDevice device))
             {
                 var msg = "ProjLab Device must be an F7Feather";
-                Logger?.Error(msg);
+                logger?.Error(msg);
                 throw new Exception(msg);
             }
 
-            Logger?.Debug("Creating comms busses...");
+            logger?.Debug("Creating comms busses...");
             var config = new SpiClockConfiguration(
                            new Frequency(48000, Frequency.UnitType.Kilohertz),
                            SpiClockConfiguration.Mode.Mode3);
 
-            SpiBus = Resolver.Device.CreateSpiBus(
+            spiBus = Resolver.Device.CreateSpiBus(
                 device.Pins.SCK,
                 device.Pins.COPI,
                 device.Pins.CIPO,
                 config);
 
-            Logger?.Debug("SPI Bus instantiated");
+            logger?.Debug("SPI Bus instantiated");
 
-            I2cBus = device.CreateI2cBus();
+            i2cBus = device.CreateI2cBus();
 
-            Logger?.Debug("I2C Bus instantiated");
+            logger?.Debug("I2C Bus instantiated");
 
             try
             {
@@ -81,38 +73,27 @@ namespace Meadow.Devices
                     device.Pins.D09, InterruptMode.EdgeRising, ResistorMode.InternalPullDown);
                 IDigitalOutputPort mcp_Reset = device.CreateDigitalOutputPort(device.Pins.D14);
 
-                mcp_1 = new Mcp23008(I2cBus, address: 0x20, mcp1_int, mcp_Reset);
+                mcp_1 = new Mcp23008(i2cBus, address: 0x20, mcp1_int, mcp_Reset);
 
-                Logger?.Trace("Mcp_1 up");
+                logger?.Trace("Mcp_1 up");
             }
             catch (Exception e)
             {
-                Logger?.Debug($"Failed to create MCP1: {e.Message}, could be a v1 board");
+                logger?.Debug($"Failed to create MCP1: {e.Message}, could be a v1 board");
             }
 
             if (mcp_1 == null)
             {
-                Logger?.Debug("Instantiating Project Lab v1 specific hardware");
-                Hardware = new ProjectLabHardwareV1(device, SpiBus, I2cBus);
+                logger?.Debug("Instantiating Project Lab v1 specific hardware");
+                hardware = new ProjectLabHardwareV1(device, spiBus, i2cBus);
             }
             else
             {
-                Logger?.Info("Instantiating Project Lab v2 specific hardware");
-                Hardware = new ProjectLabHardwareV2(device, SpiBus, I2cBus, mcp_1);
+                logger?.Info("Instantiating Project Lab v2 specific hardware");
+                hardware = new ProjectLabHardwareV2(device, spiBus, i2cBus, mcp_1);
             }
-        }
 
-        /// <summary>
-        /// Gets a ModbusRtuClient for the on-baord RS485 connector
-        /// </summary>
-        /// <param name="baudRate"></param>
-        /// <param name="dataBits"></param>
-        /// <param name="parity"></param>
-        /// <param name="stopBits"></param>
-        /// <returns></returns>
-        public ModbusRtuClient GetModbusRtuClient(int baudRate = 19200, int dataBits = 8, Parity parity = Parity.None, StopBits stopBits = StopBits.One)
-        {
-            return Hardware.GetModbusRtuClient(baudRate, dataBits, parity, stopBits);
+            return hardware;
         }
     }
 }

--- a/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
+++ b/Source/Meadow.ProjectLab/ProjectLabHardwareV2.cs
@@ -10,10 +10,10 @@ using System.Threading;
 namespace Meadow.Devices
 {
     internal class ProjectLabHardwareV2 : ProjectLabHardwareBase
-    {
-        private Mcp23008 mcp_1;
-        private Mcp23008 mcp_2;
-        private Mcp23008? mcp_Version;
+    { 
+        public Mcp23008 Mcp_1 {get;protected set;}
+        public Mcp23008 Mcp_2 { get; protected set; }
+        public Mcp23008? Mcp_Version { get; protected set; }
 
         /// <summary>
         /// Gets the ST7789 Display on the Project Lab board
@@ -43,7 +43,7 @@ namespace Meadow.Devices
             Mcp23008 mcp1
             ) : base(device, spiBus, i2cBus)
         {
-            this.mcp_1 = mcp1;
+            this.Mcp_1 = mcp1;
             IDigitalInputPort? mcp2_int = null;
 
             try
@@ -55,7 +55,7 @@ namespace Meadow.Devices
                         device.Pins.D10, InterruptMode.EdgeRising, ResistorMode.InternalPullDown);
                 }
 
-                mcp_2 = new Mcp23008(I2cBus, address: 0x21, mcp2_int);
+                Mcp_2 = new Mcp23008(I2cBus, address: 0x21, mcp2_int);
 
                 Logger?.Info("Mcp_2 up");
             }
@@ -67,7 +67,7 @@ namespace Meadow.Devices
 
             try
             {
-                mcp_Version = new Mcp23008(I2cBus, address: 0x27);
+                Mcp_Version = new Mcp23008(I2cBus, address: 0x27);
                 Logger?.Info("Mcp_Version up");
             }
             catch (Exception e)
@@ -111,13 +111,13 @@ namespace Meadow.Devices
                 // TODO: figure this out from MCP3?
                 if (revision == null)
                 {
-                    if (mcp_Version == null)
+                    if (Mcp_Version == null)
                     {
                         revision = $"v2.x";
                     }
                     else
                     {
-                        byte rev = mcp_Version.ReadFromPorts(Mcp23xxx.PortBank.A);
+                        byte rev = Mcp_Version.ReadFromPorts(Mcp23xxx.PortBank.A);
                         //mapping? 0 == d2.d?
                         revision = $"v2.{rev}";
                     }
@@ -133,7 +133,7 @@ namespace Meadow.Devices
             {
                 var port = device.CreateSerialPort(device.SerialPortNames.Com4, baudRate, dataBits, parity, stopBits);
                 port.WriteTimeout = port.ReadTimeout = TimeSpan.FromSeconds(5);
-                var serialEnable = mcp_2.CreateDigitalOutputPort(mcp_2.Pins.GP0, false);
+                var serialEnable = Mcp_2.CreateDigitalOutputPort(Mcp_2.Pins.GP0, false);
 
                 return new ModbusRtuClient(port, serialEnable);
             }

--- a/Source/ProjectLab_Demo/MeadowApp.cs
+++ b/Source/ProjectLab_Demo/MeadowApp.cs
@@ -14,7 +14,7 @@ namespace ProjLab_Demo
     {
         DisplayController displayController;
         RgbPwmLed onboardLed;
-        ProjectLab projLab;
+        IProjectLabHardware projLab;
 
         public override Task Initialize()
         {
@@ -32,7 +32,7 @@ namespace ProjLab_Demo
             Resolver.Log.Info("RGB LED up");
 
             //==== instantiate the project lab hardware
-            projLab = new ProjectLab();
+            projLab = ProjectLab.CreateProjectLab();
 
             Resolver.Log.Info($"Running on ProjectLab Hardware {projLab.RevisionString}");
 


### PR DESCRIPTION
this way folks are returned a concrete instance of the hardware version and can then access the entire set of onboard peripherals, depending on what version they're using.

still need to expose the peripherals though for each version. for instance, the v2 should have the MCPs exposed as properties

edit: exposed the MCPs, but not sure if we should expose the ports we're creating.