### PR TITLE
Add launch.config for VSCode users

### DIFF
--- a/Source/ProjectLab_Demo/.vscode/launch.config
+++ b/Source/ProjectLab_Demo/.vscode/launch.config
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Deploy",
+            "type": "meadow",
+            "request": "launch",
+            "preLaunchTask": "meadow: Build"
+        }
+    ]
+}


### PR DESCRIPTION
Part of WildernessLabs/Meadow_Issues#236.

The addition of the `.vscode` folder doesn't appear to impact VS2022 users at all, even with several folders present in a solution.  I confirmed expected debug behavior using only the Blinky C# project, but it worked as expected.